### PR TITLE
Allowing to run "python setup.py test"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [aliases]
 test=pytest
+
+[tool:pytest]
+collect_ignore = ['setup.py']

--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,11 @@ setuptools.setup(
     include_package_data=True,
     install_requires=[
         'pandas',
-        'pytest',
         'requests',
         'xlrd',
     ],
+    setup_requires=['pytest-runner'],
+    tests_require=['pytest'],
     license='Apache 2.0',
     zip_safe=False,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setuptools.setup(
         'xlrd',
     ],
     setup_requires=['pytest-runner'],
+    test_suite='tests',
     tests_require=['pytest'],
     license='Apache 2.0',
     zip_safe=False,


### PR DESCRIPTION
 @cruzzoe and I read around and came accross https://stackoverflow.com/questions/54055422/how-to-run-unit-tests-with-pip-install.

After making these changes, we can now use `python setup.py test` and `pip install maven --install-option test`.