### PR TITLE
Fix data resource locations

### DIFF
--- a/maven/datasets/general_election/uk_2010_results.py
+++ b/maven/datasets/general_election/uk_2010_results.py
@@ -28,8 +28,6 @@ class UK2010Results:
         target = self.directory / 'raw'
         os.makedirs(target, exist_ok=True)  # create directory if it doesn't exist
         sources = [
-            ('http://www.electoralcommission.org.uk/__data/assets/excel_doc/0003/105726/',
-             'GE2010-results-flatfile-website.xls'),
             ('https://s3-eu-west-1.amazonaws.com/sixfifty/',
              'GE2010-results-flatfile-website.xls')
         ]

--- a/maven/datasets/general_election/uk_2015_results.py
+++ b/maven/datasets/general_election/uk_2015_results.py
@@ -23,8 +23,8 @@ class UK2015Results:
 
     def retrieve(self):
         """Retrieve results data for the United Kingdom's 2015 General Election."""
-        url = 'http://www.electoralcommission.org.uk/__data/assets/file/0004/191650/'
-        filename = '2015-UK-general-election-data-results-WEB.zip'
+        url = 'https://www.electoralcommission.org.uk/sites/default/files/2019-08/'
+        filename = '2015-UK-general-election-data-results%20-%20CSV.zip'
         target = self.directory / 'raw'
         os.makedirs(target, exist_ok=True)  # create directory if it doesn't exist
 


### PR DESCRIPTION
I found I could not use Maven to collect data from the electoral commission website because 2 URLs no longer worked.

1. The `uk_2010_results` data is no longer on the electoral commission website due to their policy:
> We publish information about the most recent election or referendum, and the one before it. For example, you'll find information about the UK general elections that took place in 2017 and in 2015.

From https://www.electoralcommission.org.uk/who-we-are-and-what-we-do/elections-and-referendums/past-elections-and-referendums

2. The `uk_2015_results` URL has changed.